### PR TITLE
Handle segment navigation

### DIFF
--- a/.changeset/few-keys-rhyme.md
+++ b/.changeset/few-keys-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@joycostudio/transitions': patch
+---
+
+Introducing preventTransition callback, you can skip the transition pipeline and changin keys at transition route level in favor of nested RouteTransitions.

--- a/.changeset/two-taxis-accept.md
+++ b/.changeset/two-taxis-accept.md
@@ -1,0 +1,5 @@
+---
+'@joycostudio/transitions': minor
+---
+
+BREAKING CHANGE > We got rid of the weird callback object api for transition events in favor of providing the "from" and "to" values on navigation.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pnpm add @joycostudio/transitions
 
 #### `RouteTransitionManager`
 
-The main component responsible for managing route transitions. It wraps your route content and handles all transition states.
+The main component responsible for managing route transitions. It wraps your route content and handles all transition states. It NEEDS to have anchor a ref to some element so it can be preserved on unmount. If you don't want to mess the inner children layout with a wrapper just do `<div style={{ display: 'contents' }} ref={ref}>{myUltraDelicateChildren}</div>`.
 
 ```tsx
 <RouteTransitionManager
@@ -59,6 +59,7 @@ A utility component that adds a `data-transition-state` attribute to the documen
 ```
 
 #### ✨ TIP | Lock links while transitioning
+
 If you use the `<DocumentTransitionState />` component. It will attach a `data-transition-state` to the document's root. You can use it to disable all the links while the page is transitioning to make the experience feel more controlled.
 
 ```css

--- a/packages/core/core.tsx
+++ b/packages/core/core.tsx
@@ -4,7 +4,7 @@ import { SwitchTransition, Transition } from 'react-transition-group'
 import { TinyEmitter } from 'tiny-emitter'
 import { RouteConfigEntry } from '@react-router/dev/routes'
 import { matchPath } from 'react-router'
-import { nanoid } from 'nanoid'
+import { customAlphabet } from 'nanoid'
 import { useTransitionState } from './hooks'
 
 type RouteTransitionManagerProps = {
@@ -17,6 +17,7 @@ type RouteTransitionManagerProps = {
   onEntered?: (node: HTMLElement, from: string | undefined, to: string) => void
   onExiting?: (node: HTMLElement, from: string | undefined, to: string) => void
   onExited?: (node: HTMLElement, from: string | undefined, to: string) => void
+  preventTransition?: (from: string | undefined, to: string) => boolean
   appear?: boolean
   routes: RouteConfigEntry[]
 }
@@ -49,7 +50,7 @@ const getRoutesFlatMap = (routes: RouteConfigEntry[]) => {
   return routeNodeRefs
 }
 
-const navigationId = () => nanoid(5)
+const nanoid = customAlphabet('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789', 5)
 
 export const RouteTransitionManager = ({
   routes,
@@ -59,30 +60,58 @@ export const RouteTransitionManager = ({
   onExit,
   onExiting,
   onExited,
+  preventTransition,
   children,
   pathname,
   mode = 'out-in',
   appear = false,
 }: RouteTransitionManagerProps) => {
-  const prevPathnameRef = useRef<string>()
+  const callbackTimePrevPathnameRef = useRef<string>()
+  const renderTimePrevPathnameRef = useRef<string>()
   const pathnameRef = useRef(pathname)
   const transitions = useRef<Record<string, Promise<void> | undefined>>({})
-  const navigationHash = useRef(navigationId())
-
+  const prevKeyRef = useRef<string>()
+  const preventTransitionRef = useRef(preventTransition)
   const routeNodeRefs = getRoutesFlatMap(routes)
 
   useEffect(() => {
     return () => {
-      prevPathnameRef.current = pathname
-      navigationHash.current = navigationId()
+      callbackTimePrevPathnameRef.current = pathname
     }
   }, [pathname])
 
-  const key = useMemo(() => pathname + `_${navigationHash.current}`, [pathname])
   const currentMatch = useMemo(() => routeNodeRefs.find((route) => matchPath(route.path, pathname)), [pathname])
   const nodeRef = currentMatch?.nodeRef ?? createRef()
 
   pathnameRef.current = pathname
+  preventTransitionRef.current = preventTransition
+
+  /**
+   * Key changes on every pathname change. BUT 👇
+   *
+   * If preventTransition returns true, the key will not change. And will use the previous key. Why would you want to do this?
+   * If you have nested <RouteTransitionManager />, the parent manager will prevent the child manager from preserve it's exiting child on the DOM
+   * if the parent manager changes it's key. So you have to decide if you want to prevent the transition on the parent manager or not.
+   */
+  const key = useMemo(() => {
+    let nextKey
+
+    if (preventTransitionRef.current?.(renderTimePrevPathnameRef.current, pathname)) {
+      nextKey = prevKeyRef.current
+    }
+
+    return nextKey ?? nanoid()
+  }, [pathname])
+
+  prevKeyRef.current = key
+  /**
+   * Why this here and in useLayoutEffect?
+   *
+   * We need this at render time to get the previous pathname on the memoized key function.
+   * But we also need to set it again in the cleanup funtion to get the right value into the transition event callbacks eg: onEnter(node, prevPathname, pathname).
+   * Otherwise onEnter will get the updated pathname and not the previous one.
+   */
+  renderTimePrevPathnameRef.current = pathname
 
   return (
     <SwitchTransition mode={mode}>
@@ -100,7 +129,7 @@ export const RouteTransitionManager = ({
             return
           }
           transitionEvents.emit('enter', pathname)
-          transitions.current[pathname] = onEnter?.(nodeRef?.current, prevPathnameRef.current, pathnameRef.current)
+          transitions.current[pathname] = onEnter?.(nodeRef?.current, callbackTimePrevPathnameRef.current, pathname)
         }}
         onEntering={() => {
           if (!nodeRef?.current) {
@@ -108,7 +137,7 @@ export const RouteTransitionManager = ({
             return
           }
           transitionEvents.emit('entering', pathname)
-          onEntering?.(nodeRef?.current, prevPathnameRef.current, pathnameRef.current)
+          onEntering?.(nodeRef?.current, callbackTimePrevPathnameRef.current, pathname)
         }}
         onEntered={() => {
           if (!nodeRef?.current) {
@@ -116,7 +145,7 @@ export const RouteTransitionManager = ({
             return
           }
           transitionEvents.emit('entered', pathname)
-          onEntered?.(nodeRef?.current, prevPathnameRef.current, pathnameRef.current)
+          onEntered?.(nodeRef?.current, callbackTimePrevPathnameRef.current, pathname)
         }}
         /* EXIT EVENTS */
         onExit={() => {
@@ -145,7 +174,7 @@ export const RouteTransitionManager = ({
         }}
       >
         {/* @ts-expect-error - Internal use only, I don't want to type this navigationHash.current */}
-        {children(nodeRef, navigationHash.current)}
+        {children(nodeRef, key)}
       </Transition>
     </SwitchTransition>
   )

--- a/packages/core/core.tsx
+++ b/packages/core/core.tsx
@@ -8,7 +8,7 @@ import { nanoid } from 'nanoid'
 import { useTransitionState } from './hooks'
 
 type RouteTransitionManagerProps = {
-  children: (nodeRef: React.RefObject<HTMLElement | null>) => React.ReactNode
+  children: (nodeRef: React.RefObject<HTMLElement | HTMLDivElement>) => React.ReactNode
   pathname: string
   mode?: 'out-in' | 'in-out'
   onEnter: (node: HTMLElement, from: string | undefined, to: string) => Promise<void>

--- a/templates/demo/app/components/paragraph.tsx
+++ b/templates/demo/app/components/paragraph.tsx
@@ -1,0 +1,14 @@
+import cn from '@/lib/utils/cn'
+
+export const Paragraph = ({ children, className }: { children: React.ReactNode; className?: string }) => {
+  return (
+    <p
+      className={cn(
+        'text-center font-mono text-primary text-opacity-50 text-pretty whitespace-pre-wrap text-xs leading-relaxed font-medium uppercase mt-2 max-w-prose',
+        className
+      )}
+    >
+      {children}
+    </p>
+  )
+}

--- a/templates/demo/app/root.tsx
+++ b/templates/demo/app/root.tsx
@@ -109,75 +109,73 @@ export default function App() {
       appear
       routes={routes}
       pathname={location.pathname}
-      onEntering={{
-        default: () => {
-          window.scrollTo({ top: 0 })
-        },
+      onEntering={() => {
+        window.scrollTo({ top: 0 })
       }}
-      onEnter={{
-        default: (node) => {
-          return promisifyGsap(
-            gsap
-              .timeline({
-                onComplete: () => {
-                  gsap.set(node, { clearProps: 'all' })
-                },
-              })
-              .fromTo(node, { opacity: 0 }, { opacity: 1, duration: 1 })
-          )
-        },
-      }}
-      onExit={{
-        default: (node) => {
-          const animateElements = node.querySelectorAll<HTMLElement>('[data-animate]')
+      onEnter={(node, from, to) => {
+        console.log('[onEnter]', { from, to })
 
-          const groupedChunks: { [key: string]: HTMLSpanElement[] } = {}
-
-          animateElements.forEach((element) => {
-            let dataAnimate = element.getAttribute('data-animate')
-            const dataSplit = element.getAttribute('data-split') === 'true'
-
-            if (dataAnimate === 'true') {
-              dataAnimate = nanoid(10)
-            }
-
-            if (dataAnimate) {
-              if (!groupedChunks[dataAnimate]) {
-                groupedChunks[dataAnimate] = []
-              }
-
-              if (dataSplit) {
-                groupedChunks[dataAnimate].push(...split(element))
-              } else {
-                groupedChunks[dataAnimate].push(element)
-              }
-            }
-          })
-
-          const tl = gsap.timeline()
-          const factor = 0.5
-
-          Object.values(groupedChunks).forEach((chunks, idx) => {
-            tl.fromTo(
-              chunks,
-              { opacity: 1 },
-              {
-                opacity: 0,
-                duration: 0.7 * factor,
-                ease: 'sine.out',
-                stagger: {
-                  each: 0.1 * factor,
-                  ease: 'none',
-                },
+        return promisifyGsap(
+          gsap
+            .timeline({
+              onComplete: () => {
+                gsap.set(node, { clearProps: 'all' })
               },
-              idx * 0.5
-            )
-          })
+            })
+            .fromTo(node, { opacity: 0 }, { opacity: 1, duration: 1 })
+        )
+      }}
+      onExit={(node, from, to) => {
+        console.log('[onExit]', { from, to })
 
-          tl.fromTo(node, { opacity: 1 }, { opacity: 0, duration: 0.5 }, `>-=${0.2 * factor}`)
+        const animateElements = node.querySelectorAll<HTMLElement>('[data-animate]')
 
-          return promisifyGsap(tl)
-        },
+        const groupedChunks: { [key: string]: HTMLSpanElement[] } = {}
+
+        animateElements.forEach((element) => {
+          let dataAnimate = element.getAttribute('data-animate')
+          const dataSplit = element.getAttribute('data-split') === 'true'
+
+          if (dataAnimate === 'true') {
+            dataAnimate = nanoid(10)
+          }
+
+          if (dataAnimate) {
+            if (!groupedChunks[dataAnimate]) {
+              groupedChunks[dataAnimate] = []
+            }
+
+            if (dataSplit) {
+              groupedChunks[dataAnimate].push(...split(element))
+            } else {
+              groupedChunks[dataAnimate].push(element)
+            }
+          }
+        })
+
+        const tl = gsap.timeline()
+        const factor = 0.5
+
+        Object.values(groupedChunks).forEach((chunks, idx) => {
+          tl.fromTo(
+            chunks,
+            { opacity: 1 },
+            {
+              opacity: 0,
+              duration: 0.7 * factor,
+              ease: 'sine.out',
+              stagger: {
+                each: 0.1 * factor,
+                ease: 'none',
+              },
+            },
+            idx * 0.5
+          )
+        })
+
+        tl.fromTo(node, { opacity: 1 }, { opacity: 0, duration: 0.5 }, `>-=${0.2 * factor}`)
+
+        return promisifyGsap(tl)
       }}
     >
       {(ref) => (

--- a/templates/demo/app/root.tsx
+++ b/templates/demo/app/root.tsx
@@ -88,7 +88,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body>
+      <body suppressHydrationWarning>
         <Header />
         {children}
         <Footer />
@@ -109,8 +109,12 @@ export default function App() {
       appear
       routes={routes}
       pathname={location.pathname}
-      onEntering={() => {
-        window.scrollTo({ top: 0 })
+      preventTransition={(_, to) => {
+        if (to === '/prevent-transition') {
+          return true
+        }
+
+        return false
       }}
       onEnter={(node, from, to) => {
         console.log('[onEnter]', { from, to })

--- a/templates/demo/app/routes.ts
+++ b/templates/demo/app/routes.ts
@@ -1,3 +1,7 @@
 import { type RouteConfig, index, route } from '@react-router/dev/routes'
 
-export default [index('routes/home.tsx'), route('/about', 'routes/about.tsx')] satisfies RouteConfig
+export default [
+  index('routes/home.tsx'),
+  route('/about', 'routes/about.tsx'),
+  route('/prevent-transition', 'routes/prevent-transition.tsx'),
+] satisfies RouteConfig

--- a/templates/demo/app/routes/prevent-transition.tsx
+++ b/templates/demo/app/routes/prevent-transition.tsx
@@ -1,20 +1,22 @@
 import { Paragraph } from '@/components/paragraph'
-import { Link } from 'react-router'
+import { useNavigate } from 'react-router'
 
-export default function Home() {
+export default function PreventTransition() {
+  const navigate = useNavigate()
+
   return (
     <div className="flex selection:bg-primary selection:text-accent flex-col items-center h-screen bg-accent">
       <div className="flex-1 flex flex-col justify-center items-center px-4">
         <h1 data-animate data-split className="font-sans text-6xl font-bold mb-7">
-          HOMEPAGE
+          PREVENT TRANSITION PAGE
         </h1>
         <Paragraph>
           <span data-animate="paragraph" className="font-bold">
-            What are you waiting for? -
+            You can prevent transitions too!
           </span>{' '}
-          <Link data-animate="paragraph" className="underline" to="/about">
-            Change the page now!
-          </Link>
+          <button data-animate="paragraph" className="underline" onClick={() => navigate(-1)}>
+            GO BACK SMOOTHLY
+          </button>
         </Paragraph>
       </div>
     </div>

--- a/templates/demo/vite.config.ts
+++ b/templates/demo/vite.config.ts
@@ -14,8 +14,8 @@ export default defineConfig(({ isSsrBuild, command }) => ({
   build: {
     rollupOptions: isSsrBuild
       ? {
-        input: './server/app.ts',
-      }
+          input: './server/app.ts',
+        }
       : undefined,
   },
   css: {


### PR DESCRIPTION
BREAKING CHANGE > We got rid of the weird callback object API for transition events in favor of providing the "from" and "to" values on navigation.

Introducing preventTransition callback, you can skip the transition pipeline and changin keys at transition route level in favor of nested RouteTransitions.

